### PR TITLE
Feat/react query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "oew-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.40.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3850,6 +3851,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.40.0.tgz",
+      "integrity": "sha512-eD8K8jsOIq0Z5u/QbvOmfvKKE/XC39jA7yv4hgpl/1SRiU+J8QCIwgM/mEHuunQsL87dcvnHqSVLmf9pD4CiaA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.40.0.tgz",
+      "integrity": "sha512-iv/W0Axc4aXhFzkrByToE1JQqayxTPNotCoSCnarR/A1vDIHaoKpg7FTIfP3Ev2mbKn1yrxq0ZKYUdLEJxs6Tg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.40.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@tanstack/react-query": "^5.40.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,16 @@
 import './App.css'
 import MapboxMap from './components/organisms/MapBoxMap/MapboxMap'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
 
 function App() {
     return (
-        <div className="App">
-            <MapboxMap />
-        </div>
+        <QueryClientProvider client={queryClient}>
+            <div className="App">
+                <MapboxMap />
+            </div>
+        </QueryClientProvider>
     )
 }
 

--- a/src/components/organisms/MapBoxMap/MapboxMap.tsx
+++ b/src/components/organisms/MapBoxMap/MapboxMap.tsx
@@ -53,8 +53,9 @@ const MapboxMap: React.FC = () => {
         })
         // add newly selected days
         toBeAddedDays.forEach((day) => {
-            if (map.getLayer(`pred-${day}`)) {
-                map.setLayoutProperty(`pred-${day}`, 'visibility', 'visible')
+            console.log('Adding day:', day)
+            if (map.getLayer(`pred-${day}:${regionId}`)) {
+                map.setLayoutProperty(`pred-${day}:${regionId}`, 'visibility', 'visible')
             } else {
                 addPredictionLayer(map, day, regionId!)
             }

--- a/src/components/organisms/MapBoxMap/MapboxMap.tsx
+++ b/src/components/organisms/MapBoxMap/MapboxMap.tsx
@@ -3,13 +3,14 @@ import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import React, { useEffect, useRef, useState } from 'react'
 import Logo from '../../../assets/logo.png'
-import { IRegionProperties } from '../../../interfaces/IRegionProperties'
+import { IRegionData, IRegionProperties } from '../../../interfaces/IRegionProperties'
 import { fetchRegionDatetimes, fetchRegions } from '../../../services/mapService'
 import { addNavigationControls, getGlobeMap, loadStyles } from '../../../services/mapboxService'
 import { addPolygonLayer, addPredictionLayer, getBoundingBox } from '../../../services/predictionLayerService'
 import { addRegionLayer } from '../../../services/regionLayerService'
 import TopBanner from '../OEWHeader/OEWHeader'
 import './MapboxMap.css'
+import { useQuery } from '@tanstack/react-query'
 
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_KEY!
 
@@ -17,18 +18,26 @@ const MapboxMap: React.FC = () => {
     const mapContainerRef = useRef<HTMLDivElement>(null)
     const [map, setMap] = useState<mapboxgl.Map | null>(null)
     const [isSidebarOpen, setIsSidebarOpen] = useState(false)
-    const [regionId, setRegionId] = useState<number>(2)
+    // this causes the react query hook to refetch the data with the state is updated to null, so i left it emtpy
+    // const [regionId, setRegionId] = useState<number | null>(null)
+    const [regionId, setRegionId] = useState<number>()
 
     const openSidebar = () => {
         setIsSidebarOpen(!isSidebarOpen)
     }
 
     const [regionProps, setRegionProps] = useState<undefined | IRegionProperties>(undefined)
+    const [regionData, setRegionData] = useState<undefined | IRegionData>(undefined)
 
     function handleDaySelect(days: number[]) {
         let toBeAddedDays = days
         if (!map || !map.getStyle()) {
             console.error('Map is not initialized or no style is loaded')
+            return
+        }
+
+        if (regionId === null) {
+            console.error('No region selected')
             return
         }
 
@@ -47,7 +56,7 @@ const MapboxMap: React.FC = () => {
             if (map.getLayer(`pred-${day}`)) {
                 map.setLayoutProperty(`pred-${day}`, 'visibility', 'visible')
             } else {
-                addPredictionLayer(map, day, regionId)
+                addPredictionLayer(map, day, regionId!)
             }
         })
     }
@@ -58,43 +67,135 @@ const MapboxMap: React.FC = () => {
         loadStyles(map)
         addNavigationControls(map)
 
-        fetchRegions()
-            .then((regions) => {
-                addRegionLayer(map, regions)
-                map.on('click', 'regions', (e) => {
-                    setRegionId(e.features![0].properties!.id)
-                    const regionName = e.features![0].properties!.name
-                    const regionSize = e.features![0].properties!.area_km2
-
-                    const aoiPolygon: Polygon = JSON.parse(e.features![0].properties!.polygon)
-
-                    fetchRegionDatetimes(regionId).then((regionDatetimes) => {
-                        map.setLayoutProperty('regions', 'visibility', 'none')
-                        map.fitBounds(getBoundingBox(aoiPolygon))
-
-                        addPolygonLayer(map, aoiPolygon)
-                        openSidebar()
-                        const jobs = regionDatetimes.map((regionDatetimes) => regionDatetimes.timestamp)
-                        const regionProps: IRegionProperties = {
-                            id: regionId,
-                            name: regionName,
-                            jobs: jobs,
-                            areaSize: regionSize,
-                        }
-                        setRegionProps(regionProps)
-                        addPredictionLayer(map, jobs[0], regionId)
-                    })
-                })
-            })
-            .catch((error) => console.error('Failed to load regions on map:', error))
-
         return () => map.remove()
     }, [])
 
+    async function fetchRegionsWithTimeout() {
+        //timout to simulate loading
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        return await fetchRegions()
+    }
+
+    const { isPending: fetchingAoiCenters, data } = useQuery({
+        queryKey: ['regions'],
+        // queryFn: fetchRegions,
+        queryFn: async () => await fetchRegionsWithTimeout(),
+    })
+
+    useEffect(() => {
+        if (data && map) {
+            loadRegionsOnMap(data)
+        }
+    }, [data, map])
+
+    //fails on hot reload, page reload works fine
+    function loadRegionsOnMap(regions: any) {
+        if (!map) {
+            console.error('Map is not initialized')
+            return
+        }
+        addRegionLayer(map, regions)
+
+        map.on('click', 'regions', (e) => {
+            const regionId = e.features![0].properties!.id
+            const regionName = e.features![0].properties!.name
+            const regionSize = e.features![0].properties!.area_km2
+            const regionPolygon: Polygon = JSON.parse(e.features![0].properties!.polygon)
+
+            const regionData: IRegionData = {
+                id: regionId,
+                name: regionName,
+                areaSize: regionSize,
+                polygon: regionPolygon,
+            }
+
+            //this causes the react query hook to refetch the data with the new regionId
+            setRegionId(e.features![0].properties!.id)
+            setRegionData(regionData)
+
+            return
+        })
+    }
+
+    async function fetchRegionDatetimesWithTimeout(regionId: number) {
+        if (!map) return []
+        if (!regionId) return []
+
+        //timout to simulate loading
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+
+        const regionDatetimes = await fetchRegionDatetimes(regionId)
+        const regionJobs = regionDatetimes.map((regionDatetimes) => regionDatetimes.timestamp)
+        addPredictionLayer(map, regionJobs[0], regionId)
+
+        map.setLayoutProperty('regions', 'visibility', 'none')
+        map.fitBounds(getBoundingBox(regionData?.polygon!))
+
+        addPolygonLayer(map, regionData?.polygon!)
+        openSidebar()
+
+        if (regionData && regionJobs) {
+            const newRegionProps: IRegionProperties = {
+                id: regionData.id,
+                name: regionData.name,
+                areaSize: regionData.areaSize,
+                jobs: regionJobs,
+            }
+            setRegionProps(newRegionProps)
+        }
+
+        return regionDatetimes
+    }
+
+    const { isPending: fetchingRegionData } = useQuery({
+        queryKey: [`regionData${regionId}`, regionId],
+        queryFn: async () => await fetchRegionDatetimesWithTimeout(regionId!),
+        enabled: regionId !== null,
+        refetchOnWindowFocus: false,
+    })
+
     return (
-        <div>
+        <div style={{ position: 'relative' }}>
+            {fetchingAoiCenters && (
+                <div
+                    style={{
+                        zIndex: 1000,
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        backgroundColor: 'rgba(0, 0, 0, 0.7)', // Optional: This will add a semi-transparent black background
+                    }}
+                >
+                    <h1 style={{ color: 'white' }}>Loading...</h1>
+                </div>
+            )}
+
+            {fetchingRegionData && (
+                <div
+                    style={{
+                        zIndex: 1000,
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                    }}
+                >
+                    <h1 style={{ color: 'white' }}>Fetching Regions Data...</h1>
+                </div>
+            )}
+
             <TopBanner logo={Logo} isOpen={isSidebarOpen} regionProps={regionProps} handleSelectDays={handleDaySelect} map={map!}></TopBanner>
-            <div ref={mapContainerRef} className="map-container h-screen"></div>
+            <div ref={mapContainerRef} className="h-screen"></div>
         </div>
     )
 }

--- a/src/components/organisms/MapBoxMap/MapboxMap.tsx
+++ b/src/components/organisms/MapBoxMap/MapboxMap.tsx
@@ -76,6 +76,7 @@ const MapboxMap: React.FC = () => {
 
     useEffect(() => {
         const map = getGlobeMap(mapContainerRef)
+
         setMap(map)
         loadStyles(map)
         addNavigationControls(map)
@@ -85,12 +86,13 @@ const MapboxMap: React.FC = () => {
 
     const { isPending: fetchingAoiCenters, data } = useQuery({
         queryKey: ['regions'],
-        // queryFn: fetchRegions,
         queryFn: async () => await fetchRegions(),
     })
 
     useEffect(() => {
+        console.log('this is the useEffect and it dfired')
         if (data && map) {
+            console.log('actualy logic')
             loadRegionsOnMap(data)
         }
     }, [data, map])
@@ -135,7 +137,7 @@ const MapboxMap: React.FC = () => {
         const regionJobs = regionDatetimes.map((regionDatetimes) => regionDatetimes.timestamp)
 
         setFetchingPredictionsForDay(regionJobs[0])
-        //addPredictionLayer(map, regionJobs[0], regionId)
+        addPredictionLayer(map, regionJobs[0], regionId)
 
         map.setLayoutProperty('regions', 'visibility', 'none')
         map.fitBounds(getBoundingBox(regionData?.polygon!))
@@ -159,7 +161,7 @@ const MapboxMap: React.FC = () => {
     const { isPending: fetchingRegionData } = useQuery({
         queryKey: [`regionData${regionId}`, regionId],
         queryFn: async () => await fetchRegionDatetimesWithTimeout(regionId!),
-        enabled: regionId !== null,
+        enabled: !regionId,
         refetchOnWindowFocus: false,
     })
 

--- a/src/components/organisms/MapBoxMap/MapboxMap.tsx
+++ b/src/components/organisms/MapBoxMap/MapboxMap.tsx
@@ -83,16 +83,10 @@ const MapboxMap: React.FC = () => {
         return () => map.remove()
     }, [])
 
-    async function fetchRegionsWithTimeout() {
-        //timout to simulate loading
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-        return await fetchRegions()
-    }
-
     const { isPending: fetchingAoiCenters, data } = useQuery({
         queryKey: ['regions'],
         // queryFn: fetchRegions,
-        queryFn: async () => await fetchRegionsWithTimeout(),
+        queryFn: async () => await fetchRegions(),
     })
 
     useEffect(() => {
@@ -135,7 +129,7 @@ const MapboxMap: React.FC = () => {
         if (!regionId) return []
 
         //timout to simulate loading
-        await new Promise((resolve) => setTimeout(resolve, 1000))
+        //await new Promise((resolve) => setTimeout(resolve, 1000))
 
         const regionDatetimes = await fetchRegionDatetimes(regionId)
         const regionJobs = regionDatetimes.map((regionDatetimes) => regionDatetimes.timestamp)

--- a/src/interfaces/IRegionProperties.tsx
+++ b/src/interfaces/IRegionProperties.tsx
@@ -1,6 +1,15 @@
+import { Polygon } from 'geojson'
+
 export interface IRegionProperties {
     id: number
     jobs: number[]
     name: string
     areaSize: number
+}
+
+export interface IRegionData {
+    id: number
+    name: string
+    areaSize: number
+    polygon: Polygon
 }

--- a/src/services/mapService.tsx
+++ b/src/services/mapService.tsx
@@ -5,6 +5,7 @@ import { IAPIRegionDatetimes, IRegionDatetime } from '../interfaces/api/IRegionD
 
 var baseUrl = process.env.REACT_APP_API_URL
 
+//when the example value is used in the env (if none provided http://localhost:8000/ will be used) the baseUrl is not undefined and a faulty endpoint is used to make the fetches
 if (baseUrl === undefined) {
     baseUrl = 'http://localhost:8000/'
 }

--- a/src/services/predictionLayerService.tsx
+++ b/src/services/predictionLayerService.tsx
@@ -29,7 +29,7 @@ export async function addPredictionLayer(map: mapboxgl.Map, datetime: number | u
     }
 
     //timout to simulate loading
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    //await new Promise((resolve) => setTimeout(resolve, 1000))
 
     const predictions = await getJobPredictions(datetime, regionId)
 

--- a/src/services/predictionLayerService.tsx
+++ b/src/services/predictionLayerService.tsx
@@ -24,15 +24,21 @@ export function addPolygonLayer(map: mapboxgl.Map, aoi: Polygon) {
 
 export function addPredictionLayer(map: mapboxgl.Map, datetime: number, regionId: number) {
     getJobPredictions(datetime, regionId).then((predictions) => {
-        map.addSource(`pred-${datetime}`, {
+        //check if source already exists
+        if (map.getSource(`pred-${datetime}:${regionId}`)) {
+            map.removeLayer(`pred-${datetime}:${regionId}`)
+            map.removeSource(`pred-${datetime}:${regionId}`)
+        }
+
+        map.addSource(`pred-${datetime}:${regionId}`, {
             type: 'geojson',
             data: predictions,
         })
 
         map.addLayer({
-            id: `pred-${datetime}`,
+            id: `pred-${datetime}:${regionId}`,
             type: 'circle',
-            source: `pred-${datetime}`,
+            source: `pred-${datetime}:${regionId}`,
             paint: {
                 'circle-radius': 10,
                 'circle-color': [
@@ -68,7 +74,7 @@ export function addPredictionLayer(map: mapboxgl.Map, datetime: number, regionId
             closeOnClick: false,
         })
 
-        map.on('mouseenter', `pred-${datetime}`, function (e) {
+        map.on('mouseenter', `pred-${datetime}:${regionId}`, function (e) {
             map.getCanvas().style.cursor = 'pointer'
 
             if (e.features![0].geometry.type === 'Point') {
@@ -89,7 +95,7 @@ export function addPredictionLayer(map: mapboxgl.Map, datetime: number, regionId
             }
         })
 
-        map.on('mouseleave', `pred-${datetime}`, function () {
+        map.on('mouseleave', `pred-${datetime}:${regionId}`, function () {
             map.getCanvas().style.cursor = ''
             popup.remove()
         })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,20 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
-  "include": [
-    "src"
-  ]
+    "compilerOptions": {
+        "target": "es5",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noFallthroughCasesInSwitch": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx"
+    },
+    "include": ["src"]
 }


### PR DESCRIPTION
implemented react query + loading screens for endpoints:

/aoi-center
/images-by-day
/predictions-by-day-and-aoi

Loading Screens are with text description to make it easier to understand what is happening. Good for development, probably bad for Design. 

Testing: 

I used the map and looked at the server logs of the local backend to confirm that data is cached and not refetched unnecessary.


Room for improvement: 

Separation of concerns of fetching data and updating the map UI. React query can only be called inside body of react function components and are triggered by react state updates that they dependent on, similar to react hooks. Mixing the fetching data with the updating of the mapbox UI was a bit confusing when combining it with react-query as this is intended to handle the data fetching part, not so much the updating UI part. 

Side Note: 

I also updated the ID's of the prediction layers to include the regionId. Prev it was only the datetime, which caused the website to crash when to regions used the same datetime image. With the region id the bug is fixed as well