### PR TITLE
fix region bug + add clusteredLayer

### DIFF
--- a/src/components/atoms/BackButton/BackButton.tsx
+++ b/src/components/atoms/BackButton/BackButton.tsx
@@ -21,13 +21,14 @@ export const BackButton: React.FC<{ map: mapboxgl.Map }> = ({ map }) => {
         })
 
         map.removeLayer('polygon-layer')
-
         map.removeSource('polygon-source')
+        map.removeLayer('regions')
+        map.removeSource('regions')
     }
 
     function flyOutAddRegionLayer(map: mapboxgl.Map, center: mapboxgl.LngLatLike = [120.825223033, 14.642099128], zoom = 2) {
         map.on('moveend', () => {
-            map.setLayoutProperty('regions', 'visibility', 'visible')
+            map.setLayoutProperty('clusteredRegions', 'visibility', 'visible')
         })
 
         map.flyTo({

--- a/src/services/regionLayerService.tsx
+++ b/src/services/regionLayerService.tsx
@@ -1,4 +1,4 @@
-import { FeatureCollection, GeoJsonProperties, Point } from 'geojson'
+import { Feature, FeatureCollection, GeoJsonProperties, Point } from 'geojson'
 import mapboxgl from 'mapbox-gl'
 
 function capitalizeFirstLetterOfEachWord(input: string): string {
@@ -55,4 +55,63 @@ export function addRegionLayer(map: mapboxgl.Map, regions: FeatureCollection<Poi
         },
     })
     addRegionPopup(map)
+}
+
+function addClusteredRegionPopup(map: mapboxgl.Map, content: string) {
+    const popup = new mapboxgl.Popup({
+        closeButton: false,
+        closeOnClick: false,
+    })
+
+    map.on('mouseenter', 'clusteredRegions', (event) => {
+        map.getCanvas().style.cursor = 'pointer'
+
+        if (event.features![0].geometry.type === 'Point') {
+            const coordinates = event.features![0].geometry.coordinates.slice() ?? []
+            const name = event.features![0].properties?.name
+            const area = event.features![0].properties?.area_km2
+
+            while (Math.abs(event.lngLat.lng - coordinates[0]) > 180) {
+                coordinates[0] += event.lngLat.lng > coordinates[0] ? 360 : -360
+            }
+            popup.setLngLat([coordinates[0], coordinates[1]]).setHTML(content).addTo(map)
+        }
+    })
+    map.on('mouseleave', 'clusteredRegions', () => {
+        map.getCanvas().style.cursor = ''
+        popup.remove()
+    })
+}
+
+export function addClusteredRegions(map: mapboxgl.Map) {
+    const manillaBayPoint: Feature = {
+        type: 'Feature',
+        geometry: {
+            type: 'Point',
+            coordinates: [120.9749, 14.5547],
+        },
+        properties: {
+            title: 'Manila Bay',
+            description: 'Manila, Philippines',
+        },
+    }
+
+    map.addSource('clusteredRegions', {
+        type: 'geojson',
+        data: manillaBayPoint,
+    })
+
+    map.addLayer({
+        id: 'clusteredRegions',
+        type: 'circle',
+        source: 'clusteredRegions',
+        paint: {
+            'circle-color': '#ff0000',
+            'circle-radius': 9,
+            'circle-stroke-width': 6,
+            'circle-stroke-color': '#660000',
+        },
+    })
+    const popupContent: string = `<strong>Manilla Bay</strong><br>`
+    addClusteredRegionPopup(map, popupContent)
 }


### PR DESCRIPTION
- When clicking on different regions predictions of the same region where shown => bug explanation alla chat gpt:

The issue you're encountering is related to how state updates work in React. The setRegionId function updates the state, but the new state value is not immediately available after calling setRegionId. React batches state updates for performance reasons, so the regionId passed to fetchRegionDatetimes is still the old state value.

- Points appear on top of each other which is why the different regions appeared as one point in the zoomed out globe view
I added a "clustered Region" layer which is for now hard coded, after clicking on the "clustered point" the map zooms into the manilla bay region and displays the actual region center points