### PR TITLE
Feat/projection toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,13 @@
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
         "react-select": "^5.8.0",
+        "react-toggle": "^4.1.3",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "@types/mapbox-gl": "^3.1.0",
+        "@types/react-toggle": "^4.0.5",
         "prettier": "3.2.5",
         "tailwindcss": "^3.4.3"
       }
@@ -4480,6 +4482,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-toggle": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-toggle/-/react-toggle-4.0.5.tgz",
+      "integrity": "sha512-MHHEDe7GnF/EhLtI5sT70Dqab8rwlgjRZtu/u6gmfbYd+HeYxWiUSRog16+1BCfkz7Wy2VU6+TPU2oCsDtqDzA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
@@ -6135,6 +6146,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -15459,6 +15475,19 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-toggle": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/react-toggle/-/react-toggle-4.1.3.tgz",
+      "integrity": "sha512-WoPrvbwfQSvoagbrDnXPrlsxwzuhQIrs+V0I162j/s+4XPgY/YDAUmHSeWiroznfI73wj+MBydvW95zX8ABbSg==",
+      "dependencies": {
+        "classnames": "^2.2.5"
+      },
+      "peerDependencies": {
+        "prop-types": ">= 15.3.0 < 19",
+        "react": ">= 15.3.0 < 19",
+        "react-dom": ">= 15.3.0 < 19"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
     "react-select": "^5.8.0",
+    "react-toggle": "^4.1.3",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "@types/mapbox-gl": "^3.1.0",
+    "@types/react-toggle": "^4.0.5",
     "prettier": "3.2.5",
     "tailwindcss": "^3.4.3"
   }

--- a/src/components/atoms/MapProjectionButton/MapProjectionButton.css
+++ b/src/components/atoms/MapProjectionButton/MapProjectionButton.css
@@ -1,21 +1,12 @@
 .react-toggle {
     touch-action: pan-x;
-
     display: inline-block;
     position: relative;
     cursor: pointer;
     background-color: transparent;
     border: 0;
     padding: 0;
-
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
-
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-tap-highlight-color: transparent;
 }
 
@@ -25,15 +16,12 @@
     height: 1px;
     margin: -1px;
     overflow: hidden;
-    padding: 0;
     position: absolute;
     width: 1px;
 }
 
 .react-toggle--disabled {
-    cursor: not-allowed;
     opacity: 0.5;
-    -webkit-transition: opacity 0.25s;
     transition: opacity 0.25s;
 }
 
@@ -42,60 +30,45 @@
     height: 24px;
     padding: 0;
     border-radius: 30px;
-    background-color: #4d4d4d;
-    -webkit-transition: all 0.2s ease;
-    -moz-transition: all 0.2s ease;
+    background-color: var(--gray);
     transition: all 0.2s ease;
 }
 
 .react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
-    background-color: #000000;
+    background-color: var(--light-gray);
 }
 
 .react-toggle--checked .react-toggle-track {
-    background-color: #19ab27;
-}
-
-.react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
-    background-color: #128d15;
+    background-color: var(--gray);
 }
 
 .react-toggle-track-check {
     position: absolute;
     width: 14px;
     height: 10px;
-    top: 0px;
-    bottom: 0px;
-    margin-top: auto;
-    margin-bottom: auto;
+    top: 0;
+    bottom: 0;
+    margin: auto;
     line-height: 0;
     left: 8px;
     opacity: 0;
-    -webkit-transition: opacity 0.25s ease;
-    -moz-transition: opacity 0.25s ease;
     transition: opacity 0.25s ease;
 }
 
 .react-toggle--checked .react-toggle-track-check {
     opacity: 1;
-    -webkit-transition: opacity 0.25s ease;
-    -moz-transition: opacity 0.25s ease;
-    transition: opacity 0.25s ease;
 }
 
 .react-toggle-track-x {
     position: absolute;
     width: 10px;
     height: 10px;
-    top: 0px;
-    bottom: 0px;
-    margin-top: auto;
-    margin-bottom: auto;
+    top: 0;
+    bottom: 0;
+    margin: auto;
     line-height: 0;
     right: 10px;
     opacity: 1;
-    -webkit-transition: opacity 0.25s ease;
-    -moz-transition: opacity 0.25s ease;
     transition: opacity 0.25s ease;
 }
 
@@ -104,40 +77,17 @@
 }
 
 .react-toggle-thumb {
-    transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
     position: absolute;
     top: 1px;
     left: 1px;
     width: 22px;
     height: 22px;
-    border: 1px solid #4d4d4d;
     border-radius: 50%;
     background-color: #fafafa;
-
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
-
-    -webkit-transition: all 0.25s ease;
-    -moz-transition: all 0.25s ease;
-    transition: all 0.25s ease;
+    transition: all 0.25s ease, all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
 }
 
 .react-toggle--checked .react-toggle-thumb {
     left: 27px;
-    border-color: #19ab27;
 }
-
-/* I didnt like the blue shadow on the toggle button, so I commented out the following lines */
-
-/* .react-toggle--focus .react-toggle-thumb {
-    -webkit-box-shadow: 0px 0px 3px 2px #0099e0;
-    -moz-box-shadow: 0px 0px 3px 2px #0099e0;
-    box-shadow: 0px 0px 2px 3px #0099e0;
-} */
-
-/* .react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb {
-    -webkit-box-shadow: 0px 0px 5px 5px #0099e0;
-    -moz-box-shadow: 0px 0px 5px 5px #0099e0;
-    box-shadow: 0px 0px 5px 5px #0099e0;
-} */

--- a/src/components/atoms/MapProjectionButton/MapProjectionButton.css
+++ b/src/components/atoms/MapProjectionButton/MapProjectionButton.css
@@ -1,0 +1,143 @@
+.react-toggle {
+    touch-action: pan-x;
+
+    display: inline-block;
+    position: relative;
+    cursor: pointer;
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-tap-highlight-color: transparent;
+}
+
+.react-toggle-screenreader-only {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+
+.react-toggle--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    -webkit-transition: opacity 0.25s;
+    transition: opacity 0.25s;
+}
+
+.react-toggle-track {
+    width: 50px;
+    height: 24px;
+    padding: 0;
+    border-radius: 30px;
+    background-color: #4d4d4d;
+    -webkit-transition: all 0.2s ease;
+    -moz-transition: all 0.2s ease;
+    transition: all 0.2s ease;
+}
+
+.react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
+    background-color: #000000;
+}
+
+.react-toggle--checked .react-toggle-track {
+    background-color: #19ab27;
+}
+
+.react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
+    background-color: #128d15;
+}
+
+.react-toggle-track-check {
+    position: absolute;
+    width: 14px;
+    height: 10px;
+    top: 0px;
+    bottom: 0px;
+    margin-top: auto;
+    margin-bottom: auto;
+    line-height: 0;
+    left: 8px;
+    opacity: 0;
+    -webkit-transition: opacity 0.25s ease;
+    -moz-transition: opacity 0.25s ease;
+    transition: opacity 0.25s ease;
+}
+
+.react-toggle--checked .react-toggle-track-check {
+    opacity: 1;
+    -webkit-transition: opacity 0.25s ease;
+    -moz-transition: opacity 0.25s ease;
+    transition: opacity 0.25s ease;
+}
+
+.react-toggle-track-x {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    top: 0px;
+    bottom: 0px;
+    margin-top: auto;
+    margin-bottom: auto;
+    line-height: 0;
+    right: 10px;
+    opacity: 1;
+    -webkit-transition: opacity 0.25s ease;
+    -moz-transition: opacity 0.25s ease;
+    transition: opacity 0.25s ease;
+}
+
+.react-toggle--checked .react-toggle-track-x {
+    opacity: 0;
+}
+
+.react-toggle-thumb {
+    transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    width: 22px;
+    height: 22px;
+    border: 1px solid #4d4d4d;
+    border-radius: 50%;
+    background-color: #fafafa;
+
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+
+    -webkit-transition: all 0.25s ease;
+    -moz-transition: all 0.25s ease;
+    transition: all 0.25s ease;
+}
+
+.react-toggle--checked .react-toggle-thumb {
+    left: 27px;
+    border-color: #19ab27;
+}
+
+/* I didnt like the blue shadow on the toggle button, so I commented out the following lines */
+
+/* .react-toggle--focus .react-toggle-thumb {
+    -webkit-box-shadow: 0px 0px 3px 2px #0099e0;
+    -moz-box-shadow: 0px 0px 3px 2px #0099e0;
+    box-shadow: 0px 0px 2px 3px #0099e0;
+} */
+
+/* .react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb {
+    -webkit-box-shadow: 0px 0px 5px 5px #0099e0;
+    -moz-box-shadow: 0px 0px 5px 5px #0099e0;
+    box-shadow: 0px 0px 5px 5px #0099e0;
+} */

--- a/src/components/atoms/MapProjectionButton/MapProjectionButton.tsx
+++ b/src/components/atoms/MapProjectionButton/MapProjectionButton.tsx
@@ -1,21 +1,19 @@
 import React from 'react'
 import Toggle from 'react-toggle'
 import './MapProjectionButton.css'
+import { toggleMapProjection } from '../../../services/mapboxService'
 
-export type MapProjection = 'globe' | 'flat'
-
-type ToggleMapProjectionProps = {
-    currentProjection: MapProjection
-    handleOnChange: () => void
+interface MapProjectionButtonProps {
+    map: mapboxgl.Map
 }
 
-const ToggleMapProjectionButton: React.FC<ToggleMapProjectionProps> = ({ handleOnChange, currentProjection }) => {
+const MapProjectionButton: React.FC<MapProjectionButtonProps> = ({ map }) => {
     return (
         <label className="flex items-center space-x-2">
-            <Toggle defaultChecked={false} icons={false} onChange={handleOnChange} />
+            <Toggle defaultChecked={false} icons={false} onChange={() => toggleMapProjection(map)} />
             <span>Globe</span>
         </label>
     )
 }
 
-export default ToggleMapProjectionButton
+export default MapProjectionButton

--- a/src/components/atoms/MapProjectionButton/MapProjectionButton.tsx
+++ b/src/components/atoms/MapProjectionButton/MapProjectionButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import Toggle from 'react-toggle'
+import './MapProjectionButton.css'
+
+export type MapProjection = 'globe' | 'flat'
+
+type ToggleMapProjectionProps = {
+    currentProjection: MapProjection
+    handleOnChange: () => void
+}
+
+const ToggleMapProjectionButton: React.FC<ToggleMapProjectionProps> = ({ handleOnChange, currentProjection }) => {
+    return (
+        <label className="flex items-center space-x-2">
+            <Toggle defaultChecked={false} icons={false} onChange={handleOnChange} />
+            <span>Globe</span>
+        </label>
+    )
+}
+
+export default ToggleMapProjectionButton

--- a/src/components/atoms/MapProjectionButton/MapProjectionButton.tsx
+++ b/src/components/atoms/MapProjectionButton/MapProjectionButton.tsx
@@ -1,17 +1,33 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Toggle from 'react-toggle'
-import './MapProjectionButton.css'
 import { toggleMapProjection } from '../../../services/mapboxService'
+import './MapProjectionButton.css'
 
 interface MapProjectionButtonProps {
     map: mapboxgl.Map
 }
 
 const MapProjectionButton: React.FC<MapProjectionButtonProps> = ({ map }) => {
+    const [displayMap, setDisplayMap] = useState(true)
+
+    function onToggle() {
+        setDisplayMap(!displayMap)
+        toggleMapProjection(map)
+    }
+
+    function getLabel() {
+        if (displayMap) {
+            return 'Globe'
+        } else {
+            return 'Map'
+        }
+    }
+
     return (
         <label className="flex items-center space-x-2">
-            <Toggle defaultChecked={false} icons={false} onChange={() => toggleMapProjection(map)} />
-            <span>Globe</span>
+            {!displayMap && <span>Map</span>}
+            <Toggle defaultChecked={false} icons={false} onChange={onToggle} />
+            {displayMap && <span>Globe</span>}
         </label>
     )
 }

--- a/src/components/organisms/MapBoxMap/MapboxMap.tsx
+++ b/src/components/organisms/MapBoxMap/MapboxMap.tsx
@@ -91,7 +91,6 @@ const MapboxMap: React.FC = () => {
         return
     }
 
-
     useEffect(() => {
         if (predictionQueryIsSuccess && map) {
             addPredictionLayer(map, timestampToFetch!, currentAoiData!.id, predictionQueryData!)

--- a/src/components/organisms/OEWHeader/OEWHeader.css
+++ b/src/components/organisms/OEWHeader/OEWHeader.css
@@ -9,6 +9,10 @@
     z-index: 100;
     box-shadow: 0px 10px 20px black;
     backdrop-filter: blur(10px);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px;
 }
 
 #sidebar {
@@ -16,7 +20,6 @@
     box-shadow: 0px 20px 20px -10px black;
     margin-top: 5px;
     height: calc(100vh - 70px);
-    overflow-y: scroll;
     padding: 10px;
 }
 
@@ -46,13 +49,13 @@ p a:focus {
 }
 
 /* .basic-multi-select{
-  background-color: red;
+background-color: red;
 }
 
 .select__control{
-  background-color: red;
+background-color: red;
 }
 
 .select__multi-value{
-  background-color: blue;
+background-color: blue;
 } */

--- a/src/components/organisms/OEWHeader/OEWHeader.css
+++ b/src/components/organisms/OEWHeader/OEWHeader.css
@@ -17,6 +17,7 @@
 
 #sidebar {
     background-color: rgba(0, 0, 0, 0.7);
+    overflow-y: scroll;
     box-shadow: 0px 20px 20px -10px black;
     margin-top: 5px;
     height: calc(100vh - 70px);

--- a/src/components/organisms/OEWHeader/OEWHeader.tsx
+++ b/src/components/organisms/OEWHeader/OEWHeader.tsx
@@ -66,7 +66,7 @@ const OEWHeader: React.FC<OEWHeaderProps> = ({ logo, isOpen, regionProps, handle
                                 ></AreaDetails>
                                 <div className="my-12">
                                     <div className="font-bold text-sm my-5 text-left">Select Days</div>
-                                    <DaySelect days={days} handleSelectedDaysChange={handleSelectedDaysChange} />
+                                    {days.length > 0 && <DaySelect days={days} handleSelectedDaysChange={handleSelectedDaysChange} />}
                                 </div>
                             </div>
                             <ProbabilityLegend></ProbabilityLegend>

--- a/src/components/organisms/OEWHeader/OEWHeader.tsx
+++ b/src/components/organisms/OEWHeader/OEWHeader.tsx
@@ -7,6 +7,7 @@ import { BackButton } from '../../atoms/BackButton/BackButton'
 import { ProbabilityLegend } from '../../atoms/ProbabilityLegend/ProbabilityLegend'
 import DaySelect from '../../molecules/DaySelect/DaySelect'
 import './OEWHeader.css'
+import MapProjectionButton from '../../atoms/MapProjectionButton/MapProjectionButton'
 import { IRegionData } from '../MapBoxMap/types'
 import { ActionMeta } from 'react-select'
 
@@ -16,6 +17,7 @@ interface OEWHeaderProps {
     regionProps: null | IRegionData
     handleSelectedDaysChange: (event: ActionMeta<IDayOption>) => void
     handleDeselectAoi: () => void
+
     map: mapboxgl.Map
 }
 
@@ -42,49 +44,48 @@ const OEWHeader: React.FC<OEWHeaderProps> = ({ logo, isOpen, regionProps, handle
 
     return (
         <div id="header">
-            <button
-                onClick={toggleSidebar}
-                className="absolute top-2 left-2 p-2 text-xl text-white bg-gray-700 hover:bg-gray-900 focus:outline-none z-20 rounded-md"
-            >
+            <button onClick={toggleSidebar} className="p-2 text-xl text-white bg-gray-700 hover:bg-gray-900 focus:outline-none z-20 rounded-md flex ">
                 &#9776;
             </button>
-
-            {regionProps && (
-                <div
-                    className={`${
-                        isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
-                    } transform top-0 left-0 w-64 text-white fixed h-full transition-transform duration-300 ease-in-out z-10`}
-                >
-                    <div className="p-5 text-base font-bold">{regionProps?.name}</div>
-                    <div id="sidebar" className="flex flex-col items-center space-y-4">
-                        {regionProps !== undefined && (
-                            <div className="container flex flex-col justify-between h-full">
-                                <div>
-                                    <BackButton map={map} handleDeselectAoi={handleDeselectAoi}></BackButton>
-                                    <AreaDetails
-                                        areaSize={regionProps!.areaSize}
-                                        firstAnalysis={regionProps!.timestamps[0]}
-                                        lastAnalysis={regionProps!.timestamps[regionProps!.timestamps.length - 1]}
-                                        timestampsCount={regionProps!.timestamps.length}
-                                    ></AreaDetails>
-                                    <div className="my-12">
-                                        <div className="font-bold text-sm my-5 text-left">Select Days</div>
-                                        {days.length > 0 && <DaySelect days={days} handleSelectedDaysChange={handleSelectedDaysChange} />}
-                                    </div>
+            <div
+                className={`${
+                    isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
+                } transform top-0 left-0 w-64 text-white fixed h-full transition-transform duration-300 ease-in-out z-10`}
+            >
+                <div className="p-5 text-base font-bold">{regionProps?.name}</div>
+                <div id="sidebar" className="flex flex-col items-center space-y-4">
+                    {regionProps && (
+                        <div className="container flex flex-col justify-between h-full">
+                            <div>
+                                <BackButton map={map} handleDeselectAoi={handleDeselectAoi}></BackButton>
+                                <AreaDetails
+                                    areaSize={regionProps.areaSize}
+                                    firstAnalysis={regionProps.timestamps[0]}
+                                    lastAnalysis={regionProps.timestamps[regionProps.timestamps.length - 1]}
+                                    timestampsCount={regionProps.timestamps.length}
+                                ></AreaDetails>
+                                <div className="my-12">
+                                    <div className="font-bold text-sm my-5 text-left">Select Days</div>
+                                    <DaySelect days={days} handleSelectedDaysChange={handleSelectedDaysChange} />
                                 </div>
-                                <ProbabilityLegend></ProbabilityLegend>
                             </div>
-                        )}
-                    </div>
+                            <ProbabilityLegend></ProbabilityLegend>
+                        </div>
+                    )}
                 </div>
-            )}
+            </div>
 
             <div className="text-center py-2 pl-16 flex items-center justify-center">
                 <img src={logo} alt="Logo" className="h-12 inline-block mr-4" />
                 <span className="text-xl font-semibold">Ocean Eco Watch</span>
+            </div>
+
+            <div className="flex  space-x-8">
+                <MapProjectionButton map={map} />
+
                 <button
                     onClick={toggleInfo}
-                    className="absolute top-2 right-2 p-3 w-12 h-12 text-xl text-white bg-gray-700 hover:bg-gray-900 focus:outline-none z-20 rounded-full"
+                    className="p-3 w-12 h-12 text-xl text-white bg-gray-700 hover:bg-gray-900 focus:outline-none z-20 rounded-full"
                 >
                     i
                 </button>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --gray:  rgb(55 65 81);
+  --light-gray: rgb(107, 107, 107);
+  --hover-gray: rgb(17 24 39 );
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/services/mapboxService.tsx
+++ b/src/services/mapboxService.tsx
@@ -57,3 +57,12 @@ export function initMap(mapContainerRef: React.RefObject<HTMLDivElement>, setMap
 
     return map
 }
+
+export function toggleMapProjection(map: mapboxgl.Map) {
+    const currentProjection = map.getProjection()
+    if (currentProjection.name === 'globe') {
+        map.setProjection('mercator')
+    } else {
+        map.setProjection('globe')
+    }
+}


### PR DESCRIPTION
new pull request for the map projection toggle button. 

i implemented all your comments except this one: 

_in the prediction view the buttons are disabled. I would enable them and if someone changes the view from globe to map or vice versa in the prediction view I would perform the same action as if they would click on the back button._

because the map projection toggle button is now at a place where the sidebar doesn't overlay it, it is enabled when the sidebar is open. I personally think that deselecting the AOI would be a weird user experience. What we could do is to zoom out a bit, so the user recognises the change in projection. I

You also mentioned disabling the back button when the predictions are fetched to avoid errors with duplicate prediction ids. I think that is now possible no more, because the prediction layers are now referenced by region id and timestamp

I will delete the other PR and branch (there was a typo in the old branch. It was also behind dev and master so i decided it is easier to make a new branch and copy the existing coder over and fix the bugs)