### PR TITLE
add zoom in on aoi bbox when clicking on unclustered points

### DIFF
--- a/src/services/regionLayerService.tsx
+++ b/src/services/regionLayerService.tsx
@@ -2,7 +2,6 @@ import { FeatureCollection, GeoJsonProperties, Point, Polygon } from 'geojson'
 import mapboxgl from 'mapbox-gl'
 import { AoiId, IRegionData } from '../components/organisms/MapBoxMap/types'
 import { addAoiBboxLayer } from './aoiBboxLayerService'
-import { type } from 'os'
 
 function capitalizeFirstLetterOfEachWord(input: string): string {
     return input

--- a/src/services/regionLayerService.tsx
+++ b/src/services/regionLayerService.tsx
@@ -2,6 +2,7 @@ import { FeatureCollection, GeoJsonProperties, Point, Polygon } from 'geojson'
 import mapboxgl from 'mapbox-gl'
 import { AoiId, IRegionData } from '../components/organisms/MapBoxMap/types'
 import { addAoiBboxLayer } from './aoiBboxLayerService'
+import { type } from 'os'
 
 function capitalizeFirstLetterOfEachWord(input: string): string {
     return input
@@ -45,8 +46,6 @@ export function addAoiCentersLayer(
     stateSetter: (regionData: IRegionData) => void,
     setCurrentAoiId: (aoiId: AoiId) => void,
 ): void {
-    console.log('Adding aoi centers layer', regions)
-
     map.addSource('aoi-centers', {
         type: 'geojson',
         data: regions,
@@ -106,7 +105,9 @@ export function addAoiCentersLayer(
         const regionName = e.features[0].properties.name
         const regionSize = e.features[0].properties.area_km2
         const regionPolygon: Polygon = JSON.parse(e.features[0].properties.polygon)
+        const bbox = JSON.parse(e.features[0].properties.bbox)
 
+        map.fitBounds(bbox, { padding: 88 })
         hideAoiCenters(map)
         addAoiBboxLayer(map, regionPolygon)
         stateSetter({


### PR DESCRIPTION
zoom in when clicking on unclustered points. 

Parses the bbox from the geojson properties and using it in combination with the mapbox map.fitBounds method to do the zoom in. Also set a padding value to have a bit of space around the AOI after the zoom 